### PR TITLE
[Fix] PostTagテーブル/主キーがなくdestroyできない問題修正

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -30,9 +30,9 @@ class Ability
     #
     # See the wiki for details:
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities    user ||= User.new # guest user (not logged in)
-    if user.try(:admin?)
-        can :access, :rails_admin #admin管理画面へのアクセス許可
-        can :manage, :all
+    if user && user.admin?
+      can :access, :rails_admin
+      can :manage, :all
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,7 +4,7 @@ class Post < ApplicationRecord
 	has_many :favorites, dependent: :destroy
 	has_many :favorited_users, through: :favorites, source: :user
 
-	has_many :post_tags, dependent: :delete_all
+	has_many :post_tags, dependent: :destroy
 	has_many :tags, through: :post_tags
 
 	attachment :image, destroy: false

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -2,6 +2,8 @@ class PostTag < ApplicationRecord
 	belongs_to :post
 	belongs_to :tag
 
+	self.primary_key = "post_id"
+
 	validates :post_id, presence: :true
 	validates :tag_id, presence: :true
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
-	has_many :post_tags, dependent: :delete_all
+	has_many :post_tags, dependent: :destroy
 	has_many :posts, through: :post_tags
 
 	validates :name, presence: :true, length: {maximum: 50}

--- a/db/migrate/20200424051030_post_tag_to_single_p_key.rb
+++ b/db/migrate/20200424051030_post_tag_to_single_p_key.rb
@@ -1,0 +1,5 @@
+class PostTagToSinglePKey < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :post_tag, :post_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_17_113842) do
+ActiveRecord::Schema.define(version: 2020_04_24_051030) do
 
   create_table "favorites", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
- post_tagテーブル内、post_id と tag_id どちらもforeign_key: trueになっており、主キーがない状態になっていて削除行えない(destroyメソッド使えない)状態から修正