### PR TITLE
[Fix] PostTagsテーブルに主キー持たせるためdb:migrate:reset

### DIFF
--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -2,8 +2,6 @@ class PostTag < ApplicationRecord
   belongs_to :post
   belongs_to :tag
 
-  self.primary_key = "post_id"
-
   validates :post_id, presence: :true
   validates :tag_id, presence: :true
 end

--- a/db/migrate/20200424051030_post_tag_to_single_p_key.rb
+++ b/db/migrate/20200424051030_post_tag_to_single_p_key.rb
@@ -1,5 +1,0 @@
-class PostTagToSinglePKey < ActiveRecord::Migration[5.2]
-  def change
-    remove_foreign_key :post_tag, :post_id
-  end
-end

--- a/db/migrate/20200427073101_create_post_tags.rb
+++ b/db/migrate/20200427073101_create_post_tags.rb
@@ -1,6 +1,6 @@
 class CreatePostTags < ActiveRecord::Migration[5.2]
-  def change
-    create_table :post_tags, id: false do |t|
+	def change
+    create_table :post_tags do |t|
       t.references :post, foreign_key: true
       t.references :tag, foreign_key: true
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_24_051030) do
+ActiveRecord::Schema.define(version: 2020_04_27_073101) do
 
   create_table "favorites", force: :cascade do |t|
     t.integer "user_id"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2020_04_24_051030) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "post_tags", id: false, force: :cascade do |t|
+  create_table "post_tags", force: :cascade do |t|
     t.integer "post_id"
     t.integer "tag_id"
     t.index ["post_id"], name: "index_post_tags_on_post_id"


### PR DESCRIPTION
- id:falseを解除するため、post_tagsのmigrationファイル・全DBレコード削除